### PR TITLE
add Stdio server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@
 curl -N -H "Accept: text/event-stream" http://localhost:8081/sse
 ```
 
+### Connect to stdio
+Generate Java artifact
+```
+./mvnw clean install
+```
+
+Starting stdio server
+```bash
+java -Dtransport.mode=stdio \
+     -Dspring.main.web-application-type=none \
+     -Dspring.main.banner-mode=off \
+     -Dlogging.file.name=mcpserver.log \
+     -jar target/mcpserver-0.0.1-SNAPSHOT.jar
+```
+
 ### Send a tool/list request
 Example 
 
@@ -48,4 +63,3 @@ Response
 ```
 event:message
 data:{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","type":"text","text":"Current weather in San Francisco, United States of America: Partly cloudy, 11.1°C, Precipitation: 0.0 mm"}],"isError":false}}
-```


### PR DESCRIPTION
This pull request introduces new functionality for connecting to a stdio server and updates the configuration to support conditional bean creation based on the transport mode. Additionally, minor documentation improvements were made.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R11-R25): Added instructions for generating a Java artifact and starting a stdio server.

### Configuration Enhancements:
* [`src/main/java/io/github/innobridge/mcpserver/configuration/McpConfiguration.java`](diffhunk://#diff-b09896552b40ab90ab2f1b249ec5f535b46ec7869ec4a70fc2f2357355c71c1aR3): Imported `ConditionalOnProperty` to conditionally create beans based on the transport mode. [[1]](diffhunk://#diff-b09896552b40ab90ab2f1b249ec5f535b46ec7869ec4a70fc2f2357355c71c1aR3) [[2]](diffhunk://#diff-b09896552b40ab90ab2f1b249ec5f535b46ec7869ec4a70fc2f2357355c71c1aR15-R17)
* [`src/main/java/io/github/innobridge/mcpserver/configuration/McpConfiguration.java`](diffhunk://#diff-b09896552b40ab90ab2f1b249ec5f535b46ec7869ec4a70fc2f2357355c71c1aR34-R56): Added conditional bean creation for `StdioServerTransport` and updated `McpSyncServer` to use a generic `ServerMcpTransport`.