### PR TITLE
disable prompt and resouces

### DIFF
--- a/src/main/java/io/github/innobridge/mcpserver/configuration/McpConfiguration.java
+++ b/src/main/java/io/github/innobridge/mcpserver/configuration/McpConfiguration.java
@@ -63,7 +63,8 @@ public class McpConfiguration {
             .serverInfo(new Implementation("my-server", "1.0.0"))
             .capabilities(ServerCapabilities.builder()
                 .tools(true)         // Enable tool support
-                .prompts(true)       // Enable prompt support
+                .prompts(false)      // Change to false if not implementing prompts
+                .resources(false,false)
                 .logging()           // Enable logging support
                 .build())
             .build();


### PR DESCRIPTION
we are not using prompts and resource now
This pull request includes a change to the `src/main/java/io/github/innobridge/mcpserver/configuration/McpConfiguration.java` file. The change modifies the `mcpSyncServer` method to update the server capabilities configuration.

Configuration updates:

* [`src/main/java/io/github/innobridge/mcpserver/configuration/McpConfiguration.java`](diffhunk://#diff-b09896552b40ab90ab2f1b249ec5f535b46ec7869ec4a70fc2f2357355c71c1aL66-R67): Changed the `prompts` capability from `true` to `false` and added a new `resources` capability with the values `false,false`.